### PR TITLE
Fix/remove typing ext for py38 for repo

### DIFF
--- a/aws_lambda_powertools/utilities/parser/models/dynamodb.py
+++ b/aws_lambda_powertools/utilities/parser/models/dynamodb.py
@@ -2,7 +2,8 @@ from datetime import date
 from typing import Any, Dict, List, Optional
 
 from pydantic import BaseModel
-from typing_extensions import Literal
+
+from ..types import Literal
 
 
 class DynamoDBStreamChangedRecordModel(BaseModel):

--- a/aws_lambda_powertools/utilities/parser/models/kinesis.py
+++ b/aws_lambda_powertools/utilities/parser/models/kinesis.py
@@ -5,7 +5,8 @@ from typing import List
 
 from pydantic import BaseModel, validator
 from pydantic.types import PositiveInt
-from typing_extensions import Literal
+
+from ..types import Literal
 
 logger = logging.getLogger(__name__)
 

--- a/aws_lambda_powertools/utilities/parser/models/s3.py
+++ b/aws_lambda_powertools/utilities/parser/models/s3.py
@@ -5,7 +5,8 @@ from pydantic import BaseModel
 from pydantic.fields import Field
 from pydantic.networks import IPvAnyNetwork
 from pydantic.types import PositiveInt
-from typing_extensions import Literal
+
+from ..types import Literal
 
 
 class S3EventRecordGlacierRestoreEventData(BaseModel):

--- a/aws_lambda_powertools/utilities/parser/models/ses.py
+++ b/aws_lambda_powertools/utilities/parser/models/ses.py
@@ -4,7 +4,8 @@ from typing import List, Optional
 from pydantic import BaseModel, Field
 from pydantic.networks import EmailStr
 from pydantic.types import PositiveInt
-from typing_extensions import Literal
+
+from ..types import Literal
 
 
 class SesReceiptVerdict(BaseModel):

--- a/aws_lambda_powertools/utilities/parser/models/sns.py
+++ b/aws_lambda_powertools/utilities/parser/models/sns.py
@@ -3,7 +3,8 @@ from typing import Dict, List, Optional
 
 from pydantic import BaseModel, root_validator
 from pydantic.networks import HttpUrl
-from typing_extensions import Literal
+
+from ..types import Literal
 
 
 class SnsMsgAttributeModel(BaseModel):

--- a/aws_lambda_powertools/utilities/parser/models/sqs.py
+++ b/aws_lambda_powertools/utilities/parser/models/sqs.py
@@ -2,7 +2,8 @@ from datetime import datetime
 from typing import Dict, List, Optional
 
 from pydantic import BaseModel
-from typing_extensions import Literal
+
+from ..types import Literal
 
 
 class SqsAttributesModel(BaseModel):

--- a/aws_lambda_powertools/utilities/parser/types.py
+++ b/aws_lambda_powertools/utilities/parser/types.py
@@ -1,6 +1,16 @@
 """Generics and other shared types used across parser"""
+import sys
 from typing import TypeVar
 
 from pydantic import BaseModel
+
+# Workaround for not importing typing_extensions on python ^3.8
+if sys.version_info[0] > 3 or (sys.version_info[0] == 3 and sys.version_info[1] >= 8):
+    from typing import Literal  # noqa: F401
+else:
+    try:
+        from typing_extensions import Literal  # noqa: F401
+    except ImportError:
+        raise Exception("please install typing-extensions or upgrade to Python >= 3.8")
 
 Model = TypeVar("Model", bound=BaseModel)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,7 +26,7 @@ boto3 = "^1.12"
 jmespath = "^0.10.0"
 pydantic = {version = "^1.6.0", optional = true }
 email-validator = {version = "*", optional = true }
-typing_extensions = {version = "^3.7.4.2", optional = true }
+typing_extensions = {version = "^3.7.4.2", optional = true, python= "<3.8" }
 
 [tool.poetry.dev-dependencies]
 coverage = {extras = ["toml"], version = "^5.0.3"}

--- a/tests/functional/parser/schemas.py
+++ b/tests/functional/parser/schemas.py
@@ -1,7 +1,6 @@
 from typing import Dict, List, Optional
 
 from pydantic import BaseModel
-from typing_extensions import Literal
 
 from aws_lambda_powertools.utilities.parser.models import (
     DynamoDBStreamChangedRecordModel,
@@ -14,6 +13,7 @@ from aws_lambda_powertools.utilities.parser.models import (
     SqsModel,
     SqsRecordModel,
 )
+from aws_lambda_powertools.utilities.parser.types import Literal
 
 
 class MyDynamoBusiness(BaseModel):


### PR DESCRIPTION
**Issue #280**

## Description of changes:
1. Added if block to know if typing_extensions should be imported based on the python version.
if python >= 3.8 typing extensions will not be imported and the native implementation will be used
else will try to import typing_extensions and catch the ImportError

2. Updated modules which imported this dependency.
<!--- One or two sentences as a summary of what's being changed -->

3. Updated pyproject.toml to only install typing-extensions when python version is <3.8
**Checklist**

<!--- Leave unchecked if your change doesn't seem to apply --> 

* [x] [Meet tenets criteria](https://awslabs.github.io/aws-lambda-powertools-python/#tenets)
* [ ] Update tests
* [ ] Update docs
* [x] PR title follows [conventional commit semantics](https://github.com/awslabs/aws-lambda-powertools-python/blob/376ec0a2ac0d2a40e0af5717bef42ff84ca0d1b9/.github/semantic.yml#L2)

## Breaking change checklist

<!--- Ignore if it's not a breaking change -->

**RFC issue #**:

* [ ] Migration process documented
* [ ] Implement warnings (if it can live side by side)

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
